### PR TITLE
Use namespace::clean instead and have an explicit exclusion map

### DIFF
--- a/lib/MooseX/Types/Path/Tiny.pm
+++ b/lib/MooseX/Types/Path/Tiny.pm
@@ -13,7 +13,8 @@ use MooseX::Types -declare => [qw/
     Paths AbsPaths
 /];
 use Path::Tiny ();
-use namespace::autoclean;
+use namespace::clean -except => [ map { $_, 'to_' . $_, 'is_' . $_ }
+      map { $_, 'Abs' . $_ } qw( Path File Dir Paths ) ];
 
 #<<<
 subtype Path,    as 'Path::Tiny';


### PR DESCRIPTION
`namespace::autoclean` by default removes everything that doesn't look like a **method**, and as such the symbols injected by `MooseX::Types` get cleaned out, causing `06-fully-qualified.t` to fail

```
t/06-fully-qualified.t .. 
ok 1 - is_Path
ok 2 - type is available as an import
not ok 3 - type is available as a fully-qualified name
1..3

#   Failed test 'type is available as a fully-qualified name'
#   at t/06-fully-qualified.t line 14.
# Looks like you failed 1 test of 3.
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/3 subtests 

Test Summary Report
-------------------
t/06-fully-qualified.t (Wstat: 256 Tests: 3 Failed: 1)
  Failed test:  3
  Non-zero exit status: 1
```

So instead, use `namespace::clean` and have an explicit list of things not to remove.
