### PR TITLE
Enable MooseX::Getopt type map code

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for MooseX-Types-Path-Tiny
 
 {{$NEXT}}
     - repository migrated to the github moose organization
+    - add MooseX::Getopt option type maps when MooseX::Getopt is installed
 
 0.011     2014-08-30 03:17:07Z
     - documentation amendments (thanks, Demian Riccardi!)
@@ -44,4 +45,3 @@ Revision history for MooseX-Types-Path-Tiny
 
 0.001     2013-01-31 15:45:24Z
     - First release
-

--- a/lib/MooseX/Types/Path/Tiny.pm
+++ b/lib/MooseX/Types/Path/Tiny.pm
@@ -3,6 +3,7 @@ use warnings;
 package MooseX::Types::Path::Tiny;
 # ABSTRACT: Path::Tiny types and coercions for Moose
 # KEYWORDS: moose type constraint path filename directory
+# vim: set ts=8 sts=4 sw=4 tw=115 et :
 
 our $VERSION = '0.012';
 
@@ -187,5 +188,3 @@ constructors, which hold the reference for you.
 * L<Types::Path::Tiny>
 
 =cut
-
-# vim: ts=4 sts=4 sw=4 et:

--- a/lib/MooseX/Types/Path/Tiny.pm
+++ b/lib/MooseX/Types/Path/Tiny.pm
@@ -68,12 +68,24 @@ coerce(
     from ArrayRef()   => via { [ map { Path::Tiny::path($_)->absolute } @$_ ] },
 );
 
-### optionally add Getopt option type (adapted from MooseX::Types:Path::Class
-##eval { require MooseX::Getopt; };
-##if ( !$@ ) {
-##    MooseX::Getopt::OptionTypeMap->add_option_type_to_map( $_, '=s', )
-##      for ( 'Path::Tiny', Path );
-##}
+
+# optionally add Getopt option type (adapted from MooseX::Types:Path::Class)
+eval { require MooseX::Getopt; };
+if ( !$@ ) {
+    for my $type (
+        'Path::Tiny',
+        Path ,
+        AbsPath,
+        File ,
+        AbsFile,
+        Dir ,
+        AbsDir,
+        Paths ,
+        AbsPaths,
+    ) {
+        MooseX::Getopt::OptionTypeMap->add_option_type_to_map( $type, '=s', );
+    }
+}
 
 1;
 __END__


### PR DESCRIPTION
Code for this already existed but was never uncommented. I expanded it to include all of the types. This is similar to the functionality provided by [`MooseX::Types::Path::Class`](https://metacpan.org/source/ETHER/MooseX-Types-Path-Class-0.09/lib/MooseX/Types/Path/Class.pm#L34).